### PR TITLE
Improve quality of the popup header logo image

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -9,7 +9,7 @@
 	</head>
 	<body class="flex">
 		<div class="mwsBrandingHeader flex">
-			<img src="../assets/48x48.png" alt="headerImage" class="mwsHeaderImage" />
+			<img src="../assets/128x128.png" alt="headerImage" class="mwsHeaderImage" />
 		</div>
 
 		<button

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -13,13 +13,10 @@ body.flex {
 }
 
 .mwsBrandingHeader.flex {
-	/* border-bottom: 2px solid black; */
-
-	align-items: baseline;
+	align-items: center;
 }
 .mwsHeaderImage {
-	width: 80%;
-	margin: 0.2rem;
+	width: 40%;
 }
 
 .startSelectionButton {


### PR DESCRIPTION
## Describe the changes
Replaced the previous image of 48 x 48 resolution with 128 x 128 resolution. Removed unnecessary margin and reduced width from 80% to 40% as the image is bigger now. Then changed the parent's `align-items` property from baseline to center.  

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://github.com/prakhartiwari0/my-web-shortcuts/assets/65062036/b7087dd2-6e45-4479-b7b1-99d8a3145e36) | ![image](https://github.com/prakhartiwari0/my-web-shortcuts/assets/65062036/a81d568a-9511-412f-aa83-f7a7c9e995d1) |
